### PR TITLE
Added JWT mentioned in CVE-2023-51442

### DIFF
--- a/jwt.secrets.list
+++ b/jwt.secrets.list
@@ -103849,3 +103849,4 @@ nieprawdopodobnySekret
 jwtSecr3t
 guardian_sekret
 YAMohammedAssallalouIEtoMoySekretnyyKlyuch99Mar5
+not so secret


### PR DESCRIPTION
GitHub's [advisory ](https://github.com/advisories/GHSA-wq59-4q6r-635r)of https://github.com/advisories/GHSA-wq59-4q6r-635r mentions the following:

```A security vulnerability has been identified in Navidrome's subsonic endpoint, allowing for authentication bypass. This exploit enables unauthorized access to any known account by utilizing a JSON Web Token (JWT) signed with the key "not so secret".```

This pull request adds the key involved in the CVE to `jwt.secrets.list`.